### PR TITLE
Issue 4 fix

### DIFF
--- a/walle-api-server/walle_api_server/resources/login_openstack.py
+++ b/walle-api-server/walle_api_server/resources/login_openstack.py
@@ -13,8 +13,8 @@ logger = util.setup_logging(__name__)
 class LoginOpenStack(restful.Resource):
     @swagger.operation(
         responseClass=responses.LoginOpenStack,
-        nickname="login_vcloud",
-        notes="Returns information for authorization in vCloud.",
+        nickname="login_openstack",
+        notes="Returns information for authorization in OpenStack.",
         parameters=[{'name': 'user',
                      'description': 'User login.',
                      'required': True,


### PR DESCRIPTION
https://github.com/Cloudify-PS/walle-service/issues/4

vCloud renamed to OpenStack in walle_api_server/resources/login_openstack.py
